### PR TITLE
Fix Asto so there is a common upgrade path for py2 and py3 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # gateway source simlink
 gateway_src
+
+
+**/__pycache__/**

--- a/astro/configuration.py
+++ b/astro/configuration.py
@@ -1,0 +1,417 @@
+from __future__ import annotations, absolute_import
+from dataclasses import dataclass, field
+from enum import Enum
+import re
+import logging
+
+import typing
+if typing.TYPE_CHECKING:
+    from typing import Optional, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+class ConfigurationVersion(Enum):
+    V3_0 = '3.0'
+    V2_0 = '2.0'
+    V1_0 = '1.0'
+
+class SunLocation(Enum):
+    SOLAR_NOON = 'solar noon'
+    SUNSET = 'sunset'
+    CIVIL_DAWN = 'civil dawn'
+    NAUTICAL_DAWN = 'nautical dawn'
+    ASTRONOMICAL_DAWN = 'astronomical dawn'
+    ASTRONOMICAL_DUSK = 'astronomical dusk'
+    NAUTICAL_DUSK = 'nautical dusk'
+    CIVIL_DUSK = 'civil dusk'
+    SUNRISE = 'sunrise'
+
+
+@dataclass
+class GroupActionJob:
+    group_action_id: int
+    sun_location: SunLocation
+    offset: int
+
+
+class ValidationJobAction(Enum):
+    SET = 'set'
+    CLEAR = 'clear'
+
+@dataclass
+class ValidationJob:
+    action: ValidationJobAction
+    bit_id: int
+    sun_location: SunLocation
+    offset: int
+
+
+@dataclass
+class Coordinates:
+    latitude: float = None
+    longitude: float = None
+
+    def __str__(self):
+        return f"{self.latitude:.6f};{self.longitude:.6f}"
+
+    @staticmethod
+    def from_string(coord_str: str) -> Coordinates:
+        if coord_str == '':
+            return Coordinates(0.0, 0.0)
+
+        match = re.match(r'^(-?\d+[\.,]\d+).*?[;,/].*?(-?\d+[\.,]\d+)$', coord_str)
+        if match:
+            latitude = match.group(1)
+            if ',' in latitude:
+                latitude = latitude.replace(',', '.')
+            longitude = match.group(2)
+            if ',' in longitude:
+                longitude = longitude.replace(',', '.')
+            try:
+                latitude = float(latitude)
+                longitude = float(longitude)
+                return Coordinates(latitude, longitude)
+            except ValueError as ex:
+                logger.error('Could not parse coordinates: {0}'.format(ex))
+                raise
+        else:
+            raise ValueError(f"Invalid coordinates format: {coord_str}. Expected format is 'lat;long' or 'lat,long'.")
+
+
+@dataclass
+class Configuration:
+    coordinates: Coordinates = field(default_factory=lambda: Coordinates(0.0, 0.0))
+    group_action_jobs: list[GroupActionJob] = field(default_factory=list)
+    validation_jobs: list[ValidationJob] = field(default_factory=list)
+    version: ConfigurationVersion = ConfigurationVersion.V3_0
+
+
+class ConfigurationFactory:
+    def __init__(self):
+        self.config = None
+
+    def _determine_configuration_version(self, config_data: dict) -> ConfigurationVersion:
+        if 'version' in config_data:
+            version_str = config_data['version']
+            return ConfigurationVersion(version_str)
+
+        if 'basic_configuration' in config_data and 'advanced_configuration' in config_data:
+            return ConfigurationVersion.V2_0
+
+        return ConfigurationVersion.V1_0
+
+    def _migrate_configuration_v1(self, config_data: dict) -> Configuration:
+        version = self._determine_configuration_version(config_data)
+        if version != ConfigurationVersion.V1_0:
+            raise ValueError("Configuration version is not V1.0, cannot migrate.")
+
+        # location = config_data.get('location', '')
+        coordinates = config_data.get('coordinates', 'NACK')
+        horizon_bit_id = config_data.get('horizon_bit', -1)
+        civil_bit_id = config_data.get('civil_bit', -1)
+        nautical_bit_id = config_data.get('nautical_bit', -1)
+        astronomical_bit_id = config_data.get('astronomical_bit', -1)
+        bright_bit_id = config_data.get('bright_bit', -1)
+        bright_offset = config_data.get('bright_offset', 0)
+        group_action_id = config_data.get('group_action', -1)
+
+        if coordinates == 'NACK':
+            raise ValueError("Coordinates must be provided in the configuration. (location only is no longer supported)")
+
+        group_action_jobs = [] 
+        validation_jobs = []
+
+        for bit, start, stop in [
+            (horizon_bit_id, SunLocation.SUNRISE, SunLocation.SUNSET),
+            (civil_bit_id, SunLocation.CIVIL_DAWN, SunLocation.CIVIL_DUSK),
+            (nautical_bit_id, SunLocation.NAUTICAL_DAWN, SunLocation.NAUTICAL_DUSK),
+            (astronomical_bit_id, SunLocation.ASTRONOMICAL_DAWN, SunLocation.ASTRONOMICAL_DUSK),
+            (bright_bit_id, SunLocation.SOLAR_NOON, None)
+            ]:
+            if bit >= 0:
+                validation_jobs.append(ValidationJob(
+                    action=ValidationJobAction.SET,
+                    bit_id=horizon_bit_id,
+                    sun_location=start,
+                    offset=bright_offset
+                ))
+                if stop is not None:
+                    validation_jobs.append(ValidationJob(
+                        action=ValidationJobAction.CLEAR,
+                        bit_id=horizon_bit_id,
+                        sun_location=stop,
+                        offset=bright_offset
+                    ))
+                group_action_jobs.append(GroupActionJob(
+                    group_action_id=group_action_id,
+                    sun_location=start,
+                    offset=bright_offset
+                ))
+                if stop is not None:
+                    group_action_jobs.append(GroupActionJob(
+                        group_action_id=group_action_id,
+                        sun_location=stop,
+                        offset=bright_offset
+                    ))
+
+        return Configuration(
+            coordinates=Coordinates.from_string(coordinates),
+            group_action_jobs=group_action_jobs,
+            validation_jobs=validation_jobs,
+            version=ConfigurationVersion.V3_0
+        )
+
+    def _migrate_configuration_v2(self, config_data: dict) -> Configuration:
+        version = self._determine_configuration_version(config_data)
+        if version != ConfigurationVersion.V2_0:
+            raise ValueError("Configuration version is not V2.0, cannot migrate.")
+
+        coordinates = config_data.get('coordinates', '')
+        group_action_jobs = [
+            GroupActionJob(
+                group_action_id=job['group_action_id'],
+                sun_location=SunLocation(job['sun_location']),
+                offset=int(job['offset'] or 0)
+            ) for job in config_data.get('basic_configuration', [])
+        ]
+        validation_jobs = [
+            ValidationJob(
+                action=ValidationJobAction(job['action']),
+                bit_id=job['bit_id'],
+                sun_location=SunLocation(job['sun_location']),
+                offset=int(job['offset'] or 0)
+            ) for job in config_data.get('advanced_configuration', [])
+        ]
+        return Configuration(Coordinates.from_string(coordinates), group_action_jobs, validation_jobs, ConfigurationVersion.V3_0)
+
+    def _migrate_configuration_v3(self, config_data: dict) -> Configuration:
+        version = self._determine_configuration_version(config_data)
+        if version != ConfigurationVersion.V3_0:
+            raise ValueError("Configuration version is not V3.0, cannot migrate.")
+
+        coordinates = config_data.get('coordinates', '')
+        group_action_jobs = [
+            GroupActionJob(
+                group_action_id=job['group_action_id'],
+                sun_location=SunLocation(job['sun_location']),
+                offset=int(job['offset'] or 0)
+            ) for job in config_data.get('basic_configuration', [])
+        ]
+        validation_jobs = [
+            ValidationJob(
+                action=ValidationJobAction(job['action']),
+                bit_id=job['bit_id'],
+                sun_location=SunLocation(job['sun_location']),
+                offset=int(job['offset'] or 0)
+            ) for job in config_data.get('advanced_configuration', [])
+        ]
+        return Configuration(Coordinates.from_string(coordinates), group_action_jobs, validation_jobs, ConfigurationVersion.V3_0)
+
+
+    def _verify_configuration(self, config: Configuration):
+        if not config.coordinates:
+            raise ValueError("Coordinates must be provided in the configuration.")
+
+        for job in config.group_action_jobs:
+            try:
+                if isinstance(job.group_action_id, str):
+                    job.group_action_id = int(job.group_action_id)
+            except ValueError:
+                raise ValueError(f"Invalid group action ID: {job.group_action_id}, should be an integer.")
+            if job.group_action_id < 0:
+                raise ValueError(f"Invalid group action ID: {job.group_action_id}")
+
+        for job in config.validation_jobs:
+            try:
+                if isinstance(job.bit_id, str):
+                    job.bit_id = int(job.bit_id)
+            except ValueError:
+                raise ValueError(f"Invalid bit ID: {job.bit_id}, should be an integer.")
+            if job.bit_id < 0:
+                raise ValueError(f"Invalid bit ID: {job.bit_id}")
+            if job.sun_location not in SunLocation:
+                raise ValueError(f"Invalid sun location: {job.sun_location}")
+
+
+    def parse_configuration(self, config_data: dict) -> Configuration:
+        current_version = self._determine_configuration_version(config_data)
+
+        curr_config = None
+
+        if current_version == ConfigurationVersion.V1_0:
+            curr_config = self._migrate_configuration_v1(config_data)
+        elif current_version == ConfigurationVersion.V2_0:
+            curr_config = self._migrate_configuration_v2(config_data)
+        elif current_version == ConfigurationVersion.V3_0:
+            curr_config = self._migrate_configuration_v3(config_data)
+        else:
+            raise ValueError(f"Unsupported configuration version: {current_version}")
+
+        self._verify_configuration(curr_config)
+        self.config = curr_config
+        return curr_config
+
+    def get_json_configuration(self, config:Optional[Configuration] = None) -> dict[str, Any]:
+        if config is None:
+            config = self.config
+        if config is None:
+            raise ValueError("Configuration has not been parsed yet.")
+
+        return {
+            'coordinates': str(config.coordinates),
+            'basic_configuration': [
+                {
+                    'group_action_id': job.group_action_id,
+                    'sun_location': job.sun_location.value,
+                    'offset': job.offset
+                } for job in config.group_action_jobs
+            ],
+            'advanced_configuration': [
+                {
+                    'action': job.action.value,
+                    'bit_id': job.bit_id,
+                    'sun_location': job.sun_location.value,
+                    'offset': job.offset
+                } for job in config.validation_jobs
+            ],
+            'version': config.version.value
+        }
+
+    @staticmethod
+    def get_config_description() -> list:
+        # note that there is no versioning in the config description
+        # this will be added manually when the configuration changes and is passed trough the configuration factory
+        config_description = [{'name': 'coordinates',
+                               'type': 'str',
+                               'description': 'Coordinates in the form of `lat;long`.'},
+                              {'name': 'basic_configuration',
+                               'type': 'section',
+                               'description': 'Executing automations at a certain point',
+                               'repeat': True, 'min': 0,
+                               'content': [{'name': 'group_action_id',
+                                            'type': 'int',
+                                            'description': 'The Id of the Group Action / Automation that needs to be executed'},
+                                           {'name': 'sun_location',
+                                            'type': 'enum',
+                                            'description': 'The location of the sun at this point',
+                                            'choices': ['solar noon',
+                                                        'sunset', 'civil dawn', 'nautical dawn', 'astronomical dawn',
+                                                        'astronomical dusk', 'nautical dusk', 'civil dusk', 'sunrise']},
+                                           {'name': 'offset',
+                                            'type': 'str',
+                                            'description': 'Offset in minutes before (negative value) or after (positive value) the given sun location'}]},
+                              {'name': 'advanced_configuration',
+                               'type': 'section',
+                               'description': 'Setting/clearing validation bit at a certain point',
+                               'repeat': True, 'min': 0,
+                               'content': [{'name': 'action',
+                                            'type': 'enum',
+                                            'description': 'Whether to set or clear the validation bit',
+                                            'choices': ['set', 'clear']},
+                                           {'name': 'bit_id',
+                                            'type': 'int',
+                                            'description': 'The Id of the Validaten Bit that needs to set/cleared'},
+                                           {'name': 'sun_location',
+                                            'type': 'enum',
+                                            'description': 'The location of the sun at this point',
+                                            'choices': ['solar noon',
+                                                        'sunset', 'civil dawn', 'nautical dawn', 'astronomical dawn',
+                                                        'astronomical dusk', 'nautical dusk', 'civil dusk', 'sunrise']},
+                                           {'name': 'offset',
+                                            'type': 'str',
+                                            'description': 'Offset in minutes before (negative value) or after (positive value) the given sun location'}]}
+                              ]
+        return config_description
+
+    def get_default_configuration(self) -> dict[str, Any]:
+        config = Configuration(
+            coordinates=Coordinates(0.0, 0.0),
+            group_action_jobs=[],
+            validation_jobs=[],
+            version=ConfigurationVersion.V3_0
+        )
+        json_config = self.get_json_configuration(config)
+        return json_config
+
+
+
+
+
+
+
+
+
+
+
+# This is Version 2.0 of the configuration description
+    # config_description = [{'name': 'coordinates',
+    #                        'type': 'str',
+    #                        'description': 'Coordinates in the form of `lat;long`.'},
+    #                       {'name': 'basic_configuration',
+    #                        'type': 'section',
+    #                        'description': 'Executing automations at a certain point',
+    #                        'repeat': True, 'min': 0,
+    #                        'content': [{'name': 'group_action_id',
+    #                                     'type': 'int',
+    #                                     'description': 'The Id of the Group Action / Automation that needs to be executed'},
+    #                                    {'name': 'sun_location',
+    #                                     'type': 'enum',
+    #                                     'description': 'The location of the sun at this point',
+    #                                     'choices': ['solar noon',
+    #                                                 'sunset', 'civil dawn', 'nautical dawn', 'astronomical dawn',
+    #                                                 'astronomical dusk', 'nautical dusk', 'civil dusk', 'sunrise']},
+    #                                    {'name': 'offset',
+    #                                     'type': 'str',
+    #                                     'description': 'Offset in minutes before (negative value) or after (positive value) the given sun location'}]},
+    #                       {'name': 'advanced_configuration',
+    #                        'type': 'section',
+    #                        'description': 'Setting/clearing validation bit at a certain point',
+    #                        'repeat': True, 'min': 0,
+    #                        'content': [{'name': 'action',
+    #                                     'type': 'enum',
+    #                                     'description': 'Whether to set or clear the validation bit',
+    #                                     'choices': ['set', 'clear']},
+    #                                    {'name': 'bit_id',
+    #                                     'type': 'int',
+    #                                     'description': 'The Id of the Validaten Bit that needs to set/cleared'},
+    #                                    {'name': 'sun_location',
+    #                                     'type': 'enum',
+    #                                     'description': 'The location of the sun at this point',
+    #                                     'choices': ['solar noon',
+    #                                                 'sunset', 'civil dawn', 'nautical dawn', 'astronomical dawn',
+    #                                                 'astronomical dusk', 'nautical dusk', 'civil dusk', 'sunrise']},
+    #                                    {'name': 'offset',
+    #                                     'type': 'str',
+    #                                     'description': 'Offset in minutes before (negative value) or after (positive value) the given sun location'}]}
+    #                       ]
+
+
+# This is Version 1.0 of the configuration description
+    # config_description = [{'name': 'location',
+    #                        'type': 'str',
+    #                        'description': 'A written location to be translated to coordinates using Google. Leave empty and provide coordinates below to prevent using the Google services.'},
+    #                       {'name': 'coordinates',
+    #                        'type': 'str',
+    #                        'description': 'Coordinates in the form of `lat;long` where both are a decimal numbers with dot as decimal separator. Leave empty to fill automatically using the location above.'},
+    #                       {'name': 'horizon_bit',
+    #                        'type': 'int',
+    #                        'description': 'The bit that indicates whether it is day. -1 when not in use.'},
+    #                       {'name': 'civil_bit',
+    #                        'type': 'int',
+    #                        'description': 'The bit that indicates whether it is day or civil twilight. -1 when not in use.'},
+    #                       {'name': 'nautical_bit',
+    #                        'type': 'int',
+    #                        'description': 'The bit that indicates whether it is day, civil or nautical twilight. -1 when not in use.'},
+    #                       {'name': 'astronomical_bit',
+    #                        'type': 'int',
+    #                        'description': 'The bit that indicates whether it is day, civil, nautical or astronomical twilight. -1 when not in use.'},
+    #                       {'name': 'bright_bit',
+    #                        'type': 'int',
+    #                        'description': 'The bit that indicates the brightest part of the day. -1 when not in use.'},
+    #                       {'name': 'bright_offset',
+    #                        'type': 'int',
+    #                        'description': 'The offset (in minutes) after sunrise and before sunset on which the bright_bit should be set.'},
+    #                       {'name': 'group_action',
+    #                        'type': 'int',
+    #                        'description': 'The ID of a Group Action to be called when another zone is entered. -1 when not in use.'}]
+

--- a/astro/info.json
+++ b/astro/info.json
@@ -1,5 +1,5 @@
 {
-	"version" : "1.0.6",
+	"version" : "1.1.0",
 	"description" : "Astro",
 	"metric_source"  : "astro",
 	"metric_type" : "astro",

--- a/astro/main.py
+++ b/astro/main.py
@@ -3,17 +3,19 @@ An astronomical plugin, for providing the system with astronomical data (e.g. wh
 """
 
 import six
-import re
 import time
 import requests
 import logging
 import json
 from threading import Thread, Event
 from datetime import datetime, timedelta
+from .configuration import ConfigurationFactory
 from plugins.base import om_expose, background_task, OMPluginBase, PluginConfigChecker
 
 
 logger = logging.getLogger(__name__)
+
+config_factory = ConfigurationFactory()
 
 
 class Astro(OMPluginBase):
@@ -22,51 +24,12 @@ class Astro(OMPluginBase):
     """
 
     name = 'Astro'
-    version = '1.0.6'
+    version = '1.1.0'
     interfaces = [('config', '1.0')]
 
-    config_description = [{'name': 'coordinates',
-                           'type': 'str',
-                           'description': 'Coordinates in the form of `lat;long`.'},
-                          {'name': 'basic_configuration',
-                           'type': 'section',
-                           'description': 'Executing automations at a certain point',
-                           'repeat': True, 'min': 0,
-                           'content': [{'name': 'group_action_id',
-                                        'type': 'int',
-                                        'description': 'The Id of the Group Action / Automation that needs to be executed'},
-                                       {'name': 'sun_location',
-                                        'type': 'enum',
-                                        'description': 'The location of the sun at this point',
-                                        'choices': ['solar noon',
-                                                    'sunset', 'civil dawn', 'nautical dawn', 'astronomical dawn',
-                                                    'astronomical dusk', 'nautical dusk', 'civil dusk', 'sunrise']},
-                                       {'name': 'offset',
-                                        'type': 'str',
-                                        'description': 'Offset in minutes before (negative value) or after (positive value) the given sun location'}]},
-                          {'name': 'advanced_configuration',
-                           'type': 'section',
-                           'description': 'Setting/clearing validation bit at a certain point',
-                           'repeat': True, 'min': 0,
-                           'content': [{'name': 'action',
-                                        'type': 'enum',
-                                        'description': 'Whether to set or clear the validation bit',
-                                        'choices': ['set', 'clear']},
-                                       {'name': 'bit_id',
-                                        'type': 'int',
-                                        'description': 'The Id of the Validaten Bit that needs to set/cleared'},
-                                       {'name': 'sun_location',
-                                        'type': 'enum',
-                                        'description': 'The location of the sun at this point',
-                                        'choices': ['solar noon',
-                                                    'sunset', 'civil dawn', 'nautical dawn', 'astronomical dawn',
-                                                    'astronomical dusk', 'nautical dusk', 'civil dusk', 'sunrise']},
-                                       {'name': 'offset',
-                                        'type': 'str',
-                                        'description': 'Offset in minutes before (negative value) or after (positive value) the given sun location'}]}
-                          ]
+    config_description = config_factory.get_config_description()
 
-    default_config = {}
+    default_config = config_factory.get_default_configuration()
 
     def __init__(self, webinterface, connector):
         super(Astro, self).__init__(webinterface=webinterface, connector=connector)
@@ -74,6 +37,8 @@ class Astro(OMPluginBase):
 
         self._config = self.read_config(Astro.default_config)
         self._config_checker = PluginConfigChecker(Astro.config_description)
+
+        self._parsed_config = None
 
         self._latitude = None
         self._longitude = None
@@ -95,6 +60,10 @@ class Astro(OMPluginBase):
         logger.info("Started Astro plugin")
 
     def _read_config(self):
+        logger.info('Reading configuration...')
+        logger.info('Configuration: {0}'.format(self._config))
+        self._parsed_config = config_factory.parse_configuration(self._config)
+
         try:
             import pytz
             from pytz import reference
@@ -105,66 +74,50 @@ class Astro(OMPluginBase):
 
         if enabled:
             # Parse coordinates
-            coordinates = self._config.get('coordinates', '').strip()
-            match = re.match(r'^(-?\d+[\.,]\d+).*?[;,/].*?(-?\d+[\.,]\d+)$', coordinates)
-            if match:
-                latitude = match.group(1)
-                if ',' in latitude:
-                    latitude = latitude.replace(',', '.')
-                longitude = match.group(2)
-                if ',' in longitude:
-                    longitude = longitude.replace(',', '.')
-                try:
-                    self._latitude = float(latitude)
-                    self._longitude = float(longitude)
-                    self._print_coordinate_time()
-                except ValueError as ex:
-                    logger.error('Could not parse coordinates: {0}'.format(ex))
-                    enabled = False
-            else:
-                logger.error('Could not parse coordinates')
-                enabled = False
+            coordinates = self._parsed_config.coordinates
+            self._latitude = coordinates.latitude
+            self._longitude = coordinates.longitude
+            self._print_coordinate_time()
+
 
         if enabled:
-            # Parse group actions
             group_actions = {}
-            for entry in self._config.get('basic_configuration', []):
-                sun_location = entry.get('sun_location')
+            for entry in self._parsed_config.group_action_jobs:
+                sun_location = entry.sun_location.value
                 if not sun_location:
                     continue
                 try:
-                    group_action_id = int(entry.get('group_action_id'))
+                    group_action_id = int(entry.group_action_id)
                 except ValueError:
                     continue
                 try:
-                    offset = int(entry.get('offset', 0))
+                    offset = int(entry.offset or 0)
                 except ValueError:
                     offset = 0
                 actions = group_actions.setdefault(sun_location, [])
                 actions.append({'group_action_id': group_action_id,
                                 'offset': offset})
-            self._group_actions = group_actions
+                self._group_actions = group_actions
 
-            # Parse bits
             bits = {}
-            for entry in self._config.get('advanced_configuration', []):
-                sun_location = entry.get('sun_location')
+            for entry in self._parsed_config.validation_jobs:
+                sun_location = entry.sun_location
                 if not sun_location:
                     continue
-                action = entry.get('action', 'clear')
+                action = entry.action.value or 'clear'
                 try:
-                    bit_id = int(entry.get('bit_id'))
+                    bit_id = int(entry.bit_id)
                 except ValueError:
                     continue
                 try:
-                    offset = int(entry.get('offset', 0))
+                    offset = int(entry.offset or 0)
                 except ValueError:
                     offset = 0
                 actions = bits.setdefault(sun_location, [])
                 actions.append({'bit_id': bit_id,
                                 'action': action,
                                 'offset': offset})
-            self._bits = bits
+                self._bits = bits
 
         self._print_actions()
         self._enabled = enabled and (self._group_actions or self._bits)
@@ -204,18 +157,18 @@ class Astro(OMPluginBase):
         for sun_location in sun_locations:
             group_actions = self._group_actions.get(sun_location, [])
             bits = self._bits.get(sun_location, [])
-            for entry in group_actions:
-                logger.info('* At {0}{1}: Execute Automation {2}'.format(
-                    sun_location,
-                    Astro._format_offset(entry['offset']),
-                    entry['group_action_id']
-                ))
             for entry in bits:
                 logger.info('* At {0}{1}: {2} Validation Bit {3}'.format(
                     sun_location,
                     Astro._format_offset(entry['offset']),
                     entry['action'].capitalize(),
                     entry['bit_id']
+                ))
+            for entry in group_actions:
+                logger.info('* At {0}{1}: Execute Automation {2}'.format(
+                    sun_location,
+                    Astro._format_offset(entry['offset']),
+                    entry['group_action_id']
                 ))
 
     def _print_execution_plan(self):
@@ -366,17 +319,7 @@ class Astro(OMPluginBase):
                     date = self._convert(data['results'].get(field_map.get(sun_location, 'x')))
                     if date is None:
                         continue
-                    for entry in group_actions:
-                        entry_date = date + timedelta(minutes=entry['offset'])
-                        if entry_date < now:
-                            continue
-                        date_plan = execution_plan.setdefault(entry_date, [])
-                        date_plan.append({'task': 'group_action',
-                                        'source': '{0}{1}'.format(
-                                            sun_location,
-                                            Astro._format_offset(entry['offset'])
-                                        ),
-                                        'data': {'group_action_id': entry['group_action_id']}})
+
                     for entry in bits:
                         entry_date = date + timedelta(minutes=entry['offset'])
                         if entry_date < now:
@@ -389,6 +332,18 @@ class Astro(OMPluginBase):
                                         ),
                                         'data': {'action': entry['action'],
                                                 'bit_id': entry['bit_id']}})
+
+                    for entry in group_actions:
+                        entry_date = date + timedelta(minutes=entry['offset'])
+                        if entry_date < now:
+                            continue
+                        date_plan = execution_plan.setdefault(entry_date, [])
+                        date_plan.append({'task': 'group_action',
+                                        'source': '{0}{1}'.format(
+                                            sun_location,
+                                            Astro._format_offset(entry['offset'])
+                                        ),
+                                        'data': {'group_action_id': entry['group_action_id']}})
                 self._execution_plan = execution_plan
                 break
             except Exception as ex:
@@ -403,7 +358,7 @@ class Astro(OMPluginBase):
 
     @om_expose
     def get_config(self):
-        return json.dumps(self._config)
+        return json.dumps(config_factory.get_json_configuration(self._parsed_config))
 
     @om_expose
     def set_config(self, config):

--- a/astro/tests/test_astro.py
+++ b/astro/tests/test_astro.py
@@ -1,0 +1,82 @@
+import json
+from unittest import TestCase
+
+from ..configuration import ConfigurationFactory, Configuration, ConfigurationVersion, Coordinates, SunLocation, ValidationJob, GroupActionJob, ValidationJobAction
+
+
+
+
+class AstroTest(TestCase):
+    def test_calculate_mapping_v1(self):
+        config_factory = ConfigurationFactory()
+        input_config_str = '{"bright_bit":-1,"horizon_bit":200,"bright_offset":60,"location":"","astronomical_bit":-1,"nautical_bit":-1,"civil_bit":-1,"coordinates":"51.064630;3.737539","group_action":0}'
+        input_config = json.loads(input_config_str)
+
+        # import pudb; pudb.set_trace()
+        config = config_factory.parse_configuration(input_config)
+
+        expected_config = Configuration(
+                coordinates=Coordinates.from_string("51.064630;3.737539"),
+                group_action_jobs=[
+                    GroupActionJob(
+                        group_action_id=0,
+                        sun_location=SunLocation.SUNRISE,
+                        offset=60,
+                        ),
+                    GroupActionJob(
+                        group_action_id=0,
+                        sun_location=SunLocation.SUNSET,
+                        offset=60,
+                        )
+                    ],
+                validation_jobs=[
+                    ValidationJob(
+                        action=ValidationJobAction.SET,
+                        bit_id=200,
+                        sun_location=SunLocation.SUNRISE,
+                        offset=60,
+                        ),
+                    ValidationJob(
+                        action=ValidationJobAction.CLEAR,
+                        bit_id=200,
+                        sun_location=SunLocation.SUNSET,
+                        offset=60,
+                        )
+                    ],
+                version=ConfigurationVersion.V3_0
+                )
+        assert config == expected_config
+
+
+
+ 
+    def test_calculate_mapping_v2(self):
+        config_factory = ConfigurationFactory()
+        input_config_str = '{"basic_configuration":[{"sun_location":"sunset","group_action_id":3,"offset":"30"},{"sun_location":"sunrise","group_action_id":5,"offset":"-90"}],"advanced_configuration":[],"coordinates":"42.854040, 13.896781"}'
+        input_config = json.loads(input_config_str)
+
+        # import pudb; pudb.set_trace()
+        config = config_factory.parse_configuration(input_config)
+
+        expected_config = Configuration(
+                coordinates=Coordinates.from_string("42.854040;13.896781"),
+                group_action_jobs=[
+                    GroupActionJob(
+                        group_action_id=3,
+                        sun_location=SunLocation.SUNSET,
+                        offset=30,
+                        ),
+                    GroupActionJob(
+                        group_action_id=5,
+                        sun_location=SunLocation.SUNRISE,
+                        offset=-90,
+                        )
+                    ],
+                validation_jobs=[],
+                version=ConfigurationVersion.V3_0
+                )
+        assert config == expected_config
+
+
+
+ 


### PR DESCRIPTION
In an older version there was a breaking change that broke the configuration. This version will accomodate a migration path from one version to antoher and expose it in a more structured way to the gateway.