### PR TITLE
Fix keyerror errors

### DIFF
--- a/dummy_error/info.json
+++ b/dummy_error/info.json
@@ -1,5 +1,5 @@
 {
-    "version" : "0.0.1",
+    "version" : "0.0.2",
     "description" : "Dummy Error Plugin",
     "metric_source"  : "dummy_error",
     "metric_type" : "dummy_error",

--- a/dummy_error/main.py
+++ b/dummy_error/main.py
@@ -231,7 +231,6 @@ class DummyError(OMPluginBase):
             except Exception:
                 logger.exception(f"Error registering thermostat {thermostat_id}")
 
-    
     def report_thermostat_errors(self):
         for thermostat_id, errors in self._thermostat_dtos.items():
             for error in errors:
@@ -270,7 +269,6 @@ class DummyError(OMPluginBase):
                 except Exception as e:
                     logger.exception(f"Error reporting hot water {hotwater_id} error: {error} exception: {e}")
 
-
     def clear_all_errors(self):
         for hotwater_id in self._hot_water_dtos.keys():
             try:
@@ -297,24 +295,25 @@ class DummyError(OMPluginBase):
                 all_errors[f"thermostat_{thermostat_id}"] = [error.json() for error in errors]
             except Exception as e:
                 logger.exception(f"Error fetching thermostat {thermostat_id} errors: {e}")
-        
+
         logger.info(f"Fetched all errors: {all_errors}")
 
-    
     @staticmethod
     def handle_hot_water_status(event):
+        event_data = event.data or {}
         logger.info(
             "Received hot_water status from gateway: {0} {1}".format(
-                event.data["id"],
-                event.data["errors"],
+                event_data.get("id"),
+                event_data.get("errors", []),
             )
         )
 
     @staticmethod
     def handle_thermostat_status(event):
+        event_data = event.data or {}
         logger.info(
             "Received thermostat status from gateway: {0} {1}".format(
-                event.data["id"],
-                event.data["errors"],
+                event_data.get("id"),
+                event_data.get("errors", []),
             )
         )


### PR DESCRIPTION
fix for:
```
2026-04-23 16:41:17,138 - ERROR    - (IPC_plugin_processor_1) - plugin.DummyError - Error while processing status event: 'errors'
Traceback (most recent call last):
  File "/opt/openmotics/versions/service/3.14.0rc1/python/plugin_runtime/connectors/base_connector.py", line 69, in _distribute_status_event
    self._process_status_event(event=copy.deepcopy(event),
  File "/opt/openmotics/versions/service/3.14.0rc1/python/plugin_runtime/connectors/thermostat.py", line 83, in _process_status_event
    handler(event=event)
  File "/opt/openmotics/versions/service/3.14.0rc1/python/plugins/DummyError/main.py", line 318, in handle_thermostat_status
    event.data["errors"],
KeyError: 'errors'
```